### PR TITLE
[IWH-41](fix): fix husky version warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
fixed the warning that everyone would get when making commits by removing the line that was sourcing `_/husky.sh` internal script

Ticket: https://iwashere.atlassian.net/browse/IWH-41