### PR TITLE
[IWH-48](feat): implement refresh token strategy

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ export default tseslint.config(
     files: [
       '**/auth/strategies/jwt.strategy.ts',
       '**/auth/services/generate-auth-tokens.service.ts',
+      '**/auth/strategies/refresh-token.strategy.ts'
     ],
     rules: {
       '@typescript-eslint/require-await': 'off',

--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -1,0 +1,20 @@
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { RefreshTokenStrategyPayload } from '../types/refresh-token-strategy-payload.type';
+import { RefreshTokenStrategyResponse } from '../types/refresh-token-strategy-response.type';
+
+export class RefreshTokenStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([ExtractJwt.fromHeader('refresh-token')]),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_REFRESH_SECRET,
+    });
+  }
+
+  async validate(payload: RefreshTokenStrategyPayload): Promise<RefreshTokenStrategyResponse> {
+    return {
+      userId: payload.sub,
+    };
+  }
+}

--- a/src/auth/types/refresh-token-strategy-payload.type.ts
+++ b/src/auth/types/refresh-token-strategy-payload.type.ts
@@ -1,0 +1,3 @@
+export type RefreshTokenStrategyPayload = {
+  sub: number;
+};

--- a/src/auth/types/refresh-token-strategy-response.type.ts
+++ b/src/auth/types/refresh-token-strategy-response.type.ts
@@ -1,0 +1,3 @@
+export type RefreshTokenStrategyResponse = {
+  userId: number;
+};


### PR DESCRIPTION
implemented refresh token strategy that checks which searches for refresh token in `refresh-token` header and validates it,

added refresh token strategy payload and response types

disabled require await rule for refresh-token.strategy.ts

Ticket: https://iwashere.atlassian.net/browse/IWH-48